### PR TITLE
Show popup onclick rather than onmouseenter

### DIFF
--- a/app/code/community/VinaiKopp/ConfigComments/Helper/Data.php
+++ b/app/code/community/VinaiKopp/ConfigComments/Helper/Data.php
@@ -24,7 +24,7 @@ class VinaiKopp_ConfigComments_Helper_Data extends Mage_Core_Helper_Abstract
     public function getElementComments($elements)
     {
         $comments = $paths = array();
-        
+
         /** @var Varien_Data_Form_Element_Abstract $element */
         foreach ($elements as $element) {
             if ($element->getType() == 'fieldset') {
@@ -33,12 +33,12 @@ class VinaiKopp_ConfigComments_Helper_Data extends Mage_Core_Helper_Abstract
             }
             $paths[] = $element->getId();
         }
-        
+
         $this->_mergeComments($comments, $this->_loadComments($paths));
-        
+
         return $comments;
     }
-    
+
     protected function _mergeComments(&$commentTarget, $commentSource)
     {
         foreach ($commentSource as $path => $comments) {
@@ -48,7 +48,7 @@ class VinaiKopp_ConfigComments_Helper_Data extends Mage_Core_Helper_Abstract
             $commentTarget[$path] += $comments;
         }
     }
-    
+
     protected function _loadComments($paths)
     {
         if (! is_array($paths)) {
@@ -69,10 +69,10 @@ class VinaiKopp_ConfigComments_Helper_Data extends Mage_Core_Helper_Abstract
                 'author' => $comment->getAuthor()
             );
         }
-        
+
         return $comments;
     }
-    
+
     public function addCommentsToFields($elements)
     {
         foreach ($elements as $element) {
@@ -91,7 +91,7 @@ class VinaiKopp_ConfigComments_Helper_Data extends Mage_Core_Helper_Abstract
             // Add comment code
             $afterElementHtml .= <<<EOT
 <span class="vinaikopp-comments" ng-controller="FieldCtrl" ng-cloak>
-    <span ng-mouseenter="showPopup(\$event, '{$element->getId()}')">
+    <span ng-click="showPopup(\$event, '{$element->getId()}')">
         [<a href="#">{{getComments('{$element->getId()}').length}}</a>]
     </span>
 </span>
@@ -102,4 +102,4 @@ EOT;
             $element->setAfterElementHtml($afterElementHtml);
         }
     }
-} 
+}

--- a/app/design/adminhtml/default/default/template/vinaikopp/configcomments/wrapper.phtml
+++ b/app/design/adminhtml/default/default/template/vinaikopp/configcomments/wrapper.phtml
@@ -22,7 +22,7 @@
     <vk-init-comments><?php echo $initJson ?></vk-init-comments>
     <?php echo $blockHtml ?>
     <div ng-controller="PopupCtrl">
-        <div id="vinaikopp-comments-popup" 
+        <div id="vinaikopp-comments-popup"
              ng-show="isPopupVisible()" ng-mouseleave="hidePopup()" ng-click="stopEdit()">
             <span class="comment-path"><?php echo $this->__('Config Path: {{getCurrentPath()}}') ?></span>
             <span class="update-success" ng-show="updateStatus.ok"><?php echo $this->__('(Update successful)') ?></span>
@@ -31,15 +31,15 @@
                 <div class="comment" ng-class-even="'even'" ng-class-odd="'odd'">
                     <div class="rm-comment" ng-hide="isInlineEdit($index)"
                          ng-click="remove($index)" vk-stop-event="click">&times;</div>
-                    <div class="comment-text" ng-hide="isInlineEdit($index)" 
+                    <div class="comment-text" ng-hide="isInlineEdit($index)"
                          ng-click="startEdit($index)" vk-stop-event="click">{{comment.text}}</div>
-                    <textarea class="edit-comment" rows="2" ng-model="editComment.text" 
+                    <textarea class="edit-comment" rows="2" ng-model="editComment.text"
                               ng-show="isInlineEdit($index)" vk-stop-event="click" ng-keydown="isTab($event) && stopEdit()"></textarea>
                     <span class="comment-author">{{comment.author}}</span>
                 </div>
             </div>
             <span class="add-new-comment">
-                <textarea class="new-comment" name="new-comment" rows="2" 
+                <textarea class="new-comment" name="new-comment" rows="2"
                           ng-model="newComment.text" autofocus="autofocus"></textarea>
                 <button ng-click="addNew()"><?php echo $this->__('Add') ?></button>
                 <span class="new-comment-author">{{getCurrentAuthor()}}</span>

--- a/skin/adminhtml/default/default/vinaikopp/configcomments/comment.js
+++ b/skin/adminhtml/default/default/vinaikopp/configcomments/comment.js
@@ -42,7 +42,7 @@ commentsApp
                 var empty = idxProvided ? {} : [];
                 if (! this.comments[path]) return empty;
                 else if (! idxProvided) return this.comments[path];
-                
+
                 if (! this.comments[path][idx]) return empty;
                 else return this.comments[path][idx];
             },
@@ -61,7 +61,7 @@ commentsApp
                 var path = this.currentPath;
                 if (this.newComment.text.length > 0 && path.length > 0) {
                     if (! this.comments[path]) this.comments[path] = [];
-                    
+
                     this.newComment.author = initData.author;
                     this.comments[path].push(angular.copy(this.newComment));
                     this.newComment.text = '';
@@ -75,7 +75,7 @@ commentsApp
                     this.comments[path][idx] = angular.copy(this.editComment);
                     this.persist();
                 }
-                this.editComment.text = '';  
+                this.editComment.text = '';
             },
             remove: function(idx) {
                 var path = this.currentPath;
@@ -101,7 +101,7 @@ commentsApp
                             this.updateStatus.fail = data.fail && data.fail.length;
                             this.updateStatus.error = data.error ? data.error : false;
                             $timeout(this.resetUpdateStatus.bind(this), 3000);
-                            
+
                         }.bind(this))
                         .error(function(data, status, headers, config) {
                             console.log('Update error!');
@@ -124,14 +124,14 @@ commentsApp
             visible: false,
             show: function(e) {
                 // Find the matching config value table cell
-                var rel = $(e.fromElement);
+                var rel = $(e.target);
                 if (! rel) rel = e.relatedTarget;
                 if (! rel.match('td.value') && ! (rel = rel.up('td.value')))
                     return;
-    
+
                 // Set visibility flag
                 this.visible = true;
-                
+
                 // Move to position
                 var t = this.offset(angular.element(rel));
                 $('vinaikopp-comments-popup').setStyle({
@@ -163,24 +163,24 @@ commentsApp
     .controller('FieldCtrl', function($scope, Comments, Popup) {
         var commentService = Comments;
         var popupService = Popup;
-        
+
         $scope.getComments = function(path) {
             return commentService.getComments(path);
         };
         $scope.showPopup = function($event, path) {
             commentService.setPath(path);
             popupService.show($event);
-        }
+        };
     })
     .controller('PopupCtrl', function ($scope, Comments, Popup, initData) {
         var commentService = Comments;
         var popupService = Popup;
         var inlineEditEnabled = false;
-        
+
         $scope.newComment = commentService.newComment;
         $scope.editComment = commentService.editComment;
         $scope.updateStatus = commentService.updateStatus
-        
+
         $scope.getCurrentComments = function() {
             return commentService.getCurrent();
         };
@@ -216,6 +216,6 @@ commentsApp
             }
         }
         $scope.isTab = function($event) {
-            return $event.keyCode && $event.keyCode == 9; 
+            return $event.keyCode && $event.keyCode == 9;
         }
     });


### PR DESCRIPTION
I replaced the ng-mouseenter directive with a ng-click directive since I find it annoying when a popup shows up immediately after the mouse enters the comment count link. Since it is a link I think it's more natural to show the popup after clicking the link.

I also tried implementing a timout for the mouseenter directive, but I ran out of time.

Thought: Maybe this behavior can be toggled via configuration option from the backend. But it seems a bit oversized for such a small and simple module.
